### PR TITLE
Replace fontawesome with fontawesome5

### DIFF
--- a/inst/rmarkdown/templates/cover_letter/resources/template.tex
+++ b/inst/rmarkdown/templates/cover_letter/resources/template.tex
@@ -413,7 +413,7 @@ $endif$
 
 $if(title)$
 \title{$title$$if(subtitle)$: $subtitle$$endif$$if(anonymous)$$else$$if(thanks)$\thanks{$thanks$} $endif$$endif$ }
-$endif$ 
+$endif$
 
 
 
@@ -460,7 +460,7 @@ $endif$
 \hypersetup{breaklinks=true,
             bookmarks=true,
             pdfauthor={$if(anonymous)$$else$$for(author)$$author.name$ ($author.affiliation$)$sep$ and $endfor$$endif$},
-             pdfkeywords = {$if(keywords)$$keywords$$endif$},  
+             pdfkeywords = {$if(keywords)$$keywords$$endif$},
             pdftitle={$title$$if(subtitle)$: $subtitle$$endif$},
             colorlinks=true,
             citecolor=$if(citecolor)$$citecolor$$else$blue$endif$,
@@ -484,7 +484,7 @@ $endif$
 
 % This will better treat References as a section when using natbib
 % https://tex.stackexchange.com/questions/49962/bibliography-title-fontsize-problem-with-bibtex-and-the-natbib-package
-$if(natbib)$ 
+$if(natbib)$
 \renewcommand\bibsection{%
    \section*{References}%
    \markboth{\MakeUppercase{\refname}}{\MakeUppercase{\refname}}%
@@ -505,7 +505,7 @@ $endfor$
 
 \newtheorem{hypothesis}{Hypothesis}
 
-$if(fontawesome)$\usepackage{fontawesome}$else$$endif$
+$if(fontawesome)$\usepackage{fontawesome5}$else$$endif$
 
 \newcommand{\blankline}{\quad\pagebreak[2]}
 \usepackage{graphicx}
@@ -520,13 +520,13 @@ $if(fontawesome)$\usepackage{fontawesome}$else$$endif$
 {\bfseries $author$ }\\[.35ex]
 \emph{\small $address$} \\[.35ex]
 $if(phone)$$if(fontawesome)$\faPhone \hspace{1 mm}$else$$endif$ \small{$phone$} \\ $else$$endif$
-$if(email)$$if(fontawesome)$\faEnvelopeO \hspace{1 mm}$else$$endif$ \small{\tt $email$} \\ $else$$endif$
+$if(email)$$if(fontawesome)$\faEnvelope \hspace{1 mm}$else$$endif$ \small{\tt $email$} \\ $else$$endif$
 $if(url)$$if(fontawesome)$\faGlobe \hspace{1 mm}$else$$endif$ \small{\href{http://$url$}{\tt $url$}}\\ $else$$endif$
 \hspace{1cm} \\
 $if(date)$ $date$ \\ $else$$endif$
 \end{minipage}
 
-% \vspace*{1em} 
+% \vspace*{1em}
 
 $if(greetings)$
 \vspace*{1em}
@@ -535,11 +535,11 @@ $greetings$
 
 \vspace*{1em}
 
-$else$$endif$ 
+$else$$endif$
 
 % $if(date)$$date$
-% 
-% \vspace*{1em} 
+%
+% \vspace*{1em}
 % $else$$endif$
 
 % $if(pandocparas)$
@@ -589,4 +589,3 @@ $include-after$
 
 $endfor$
 \end{document}
-

--- a/inst/rmarkdown/templates/cv/resources/template.tex
+++ b/inst/rmarkdown/templates/cv/resources/template.tex
@@ -191,7 +191,7 @@ $endfor$
 \titlespacing\subsection{0pt}{12pt plus 4pt minus 2pt}{4pt plus 2pt minus 2pt}
 
 % Use fontawesome. Note: you'll need TeXLive 2015. Update.
-$if(fontawesome)$\usepackage{fontawesome}$endif$
+$if(fontawesome)$\usepackage{fontawesome5}$endif$
 
 % Fancyhdr, as I tend to do with these personal documents.
 \usepackage{fancyhdr,lastpage}
@@ -255,7 +255,7 @@ $endif$
 
 $if(jobtitle)$\moveleft.5\hoffset\centerline{$jobtitle$}$endif$
 $if(address)$\moveleft.5\hoffset\centerline{$address$}$endif$
-\moveleft.5\hoffset\centerline{ $if(email)$$if(fontawesome)$\faEnvelopeO \hspace{1 mm}$else$\emph{E-mail:}$endif$ \href{mailto:}{\tt $email$} \hspace{1 mm}$endif$ $if(phone)$$if(fontawesome)$ \faPhone \hspace{1 mm}$else$\emph{Phone:}$endif$  $phone$  \hspace{1 mm} $endif$ $if(github)$$if(fontawesome)$\faGithub \hspace{1 mm}$else$\emph{Github:}$endif$ \href{http://github.com/$github$}{\tt $github$} \hspace{1 mm} $endif$  $if(twitter)$$if(fontawesome)$\faTwitter \hspace{1 mm}$else$\emph{Twitter:}$endif$ \href{https:/twitter.com/$twitter$}{\tt $twitter$} \hspace{1 mm} $endif$ $if(osf)$$if(fontawesome)$\faUnlock \hspace{1 mm}$else$\emph{osf:}$endif$ \href{https:/osf.io/$osf$}{\tt osf.io/$osf$} \hspace{1 mm} $endif$ $if(orcid)$$if(fontawesome)$\orcidlink{$orcid$} \hspace{.5 mm}$else$\emph{ORCID:}$endif$ \href{https://orcid.org/$orcid$}{\tt $orcid$} \hspace{1 mm} $endif$ $if(web)$$if(fontawesome)$\faGlobe \hspace{1 mm}$else$\emph{Web:}$endif$ \href{http://$web$}{\tt $web$}  $endif$ $if(updated)$ | \emph{Updated:} $if(rdateformat)$$rdateformat$$else$\apstylekinda\today$endif$$endif$}
+\moveleft.5\hoffset\centerline{ $if(email)$$if(fontawesome)$\faEnvelope \hspace{1 mm}$else$\emph{E-mail:}$endif$ \href{mailto:}{\tt $email$} \hspace{1 mm}$endif$ $if(phone)$$if(fontawesome)$ \faPhone \hspace{1 mm}$else$\emph{Phone:}$endif$  $phone$  \hspace{1 mm} $endif$ $if(github)$$if(fontawesome)$\faGithub \hspace{1 mm}$else$\emph{Github:}$endif$ \href{http://github.com/$github$}{\tt $github$} \hspace{1 mm} $endif$  $if(twitter)$$if(fontawesome)$\faTwitter \hspace{1 mm}$else$\emph{Twitter:}$endif$ \href{https:/twitter.com/$twitter$}{\tt $twitter$} \hspace{1 mm} $endif$ $if(osf)$$if(fontawesome)$\faUnlock \hspace{1 mm}$else$\emph{osf:}$endif$ \href{https:/osf.io/$osf$}{\tt osf.io/$osf$} \hspace{1 mm} $endif$ $if(orcid)$$if(fontawesome)$\orcidlink{$orcid$} \hspace{.5 mm}$else$\emph{ORCID:}$endif$ \href{https://orcid.org/$orcid$}{\tt $orcid$} \hspace{1 mm} $endif$ $if(web)$$if(fontawesome)$\faGlobe \hspace{1 mm}$else$\emph{Web:}$endif$ \href{http://$web$}{\tt $web$}  $endif$ $if(updated)$ | \emph{Updated:} $if(rdateformat)$$rdateformat$$else$\apstylekinda\today$endif$$endif$}
 
 
 
@@ -289,4 +289,3 @@ $include-after$
 
 $endfor$
 \end{document}
-

--- a/inst/rmarkdown/templates/resume/resources/template.tex
+++ b/inst/rmarkdown/templates/resume/resources/template.tex
@@ -321,7 +321,7 @@ $endif$
                     \affil{$author.affiliation$}
                 $endif$
             $endif$
-            $else$  
+            $else$
             \author{$author$}
         $endif$
     $endfor$
@@ -348,7 +348,7 @@ $endif$
 \makeatother
 
 % Use fontawesome. Note: you'll need TeXLive 2015. Update.
-$if(fontawesome)$\usepackage{fontawesome}$endif$
+$if(fontawesome)$\usepackage{fontawesome5}$endif$
 
 % Mess with sections
 \usepackage{titlesec}
@@ -366,7 +366,7 @@ $if(includephoto)$
 \usepackage{graphicx}
 \usepackage{tikz}
 \usepackage{tikzpagenodes}
-\usetikzlibrary{calc} 
+\usetikzlibrary{calc}
 $endif$
 
 
@@ -428,13 +428,13 @@ $endif$ % includephoto
 
 \flushleft{\footnotesize
 
-$if(email)$$if(fontawesome)$\faEnvelopeO \hspace{1 mm}$else$\emph{E-mail:}$endif$ \href{mailto:}{\tt $email$} \hspace{1 mm}$endif$
+$if(email)$$if(fontawesome)$\faEnvelope \hspace{1 mm}$else$\emph{E-mail:}$endif$ \href{mailto:}{\tt $email$} \hspace{1 mm}$endif$
 $if(email)$$if(fontawesome)$\faPhone \hspace{1 mm}$else$\emph{Phone:}$endif$ $phone$ \hspace{1 mm}$endif$
 $if(email)$$if(fontawesome)$\faMapMarker \hspace{1 mm}$else$\emph{Location:}$endif$ $location$ \hspace{1 mm}$endif$
 }
 \vspace{-1em}
 \flushleft{\footnotesize
-$if(web)$$if(fontawesome)$\faGlobe \hspace{1 mm}$else$\emph{Web:}$endif$ \href{http://$web$}{\tt $web$}  \hspace{1 mm}$endif$ 
+$if(web)$$if(fontawesome)$\faGlobe \hspace{1 mm}$else$\emph{Web:}$endif$ \href{http://$web$}{\tt $web$}  \hspace{1 mm}$endif$
 $if(email)$$if(fontawesome)$\faTwitter \hspace{1 mm}$else$\emph{Twitter:}$endif$ \href{http://twitter.com/$twitter$}{\tt $twitter$} \hspace{1 mm}$endif$
 $if(email)$$if(fontawesome)$\faLinkedin \hspace{1 mm}$else$\emph{LinkedIn:}$endif$ \href{https://www.linkedin.com/in/$linkedin$}{\tt $linkedin$} \hspace{1 mm}$endif$
 $if(email)$$if(fontawesome)$\faGithub \hspace{1 mm}$else$\emph{Github:}$endif$ \href{http://github.com/$github$}{\tt $github$} \hspace{1 mm}$endif$
@@ -443,4 +443,3 @@ $if(email)$$if(fontawesome)$\faGithub \hspace{1 mm}$else$\emph{Github:}$endif$ \
 $body$
 
 \end{document}
-


### PR DESCRIPTION
Requesting to replace FA with FA5 in the cover_letter, cv, and resume templates. I noted in your now-deprcated repository, svm-r-markdown-templates, that fontawesome was failing on the templates apparently due to a change in package names. See: https://github.com/svmiller/svm-r-markdown-templates/issues/31