### PR TITLE
Added xurl dependency

### DIFF
--- a/inst/rmarkdown/templates/cover_letter/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cover_letter/skeleton/skeleton.Rmd
@@ -3,6 +3,7 @@ output: stevetemplates::cover_letter
 geometry: margin=1in
 header-includes:
   - \linespread{1.05}
+  - \usepackage{xurl}
 
 author: Steven V. Miller
 address: |


### PR DESCRIPTION
Adding the xurl dependency fixes the issues when rendering using the tinytex installation. This forces tinytex to install the missing LaTeX package