### PR TITLE
remove table of contents from the end of the template

### DIFF
--- a/inst/rmarkdown/templates/beamer/resources/template.tex
+++ b/inst/rmarkdown/templates/beamer/resources/template.tex
@@ -422,7 +422,4 @@ $include-after$
 
 $endfor$
 
-\section[]{}
-\frame{\small \frametitle{Table of Contents}
-\tableofcontents}
 \end{document}


### PR DESCRIPTION
this removes the table of contents that's hardcoded to the end of the beamer template, resolving issue #10.  I haven't validated the behavior of `toc: TRUE` to see what other options are available for a table of contents, but have confirmed that the skeleton will not produce a mandatory trailing TOC.